### PR TITLE
Rc 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ with UBXSimulator(
         print(parsed)
 ```
 
-Generates mock acknowledgements (ACK-ACK) for valid incoming UBX commands and polls.
+Generates mock acknowledgements (ACK-ACK) for valid incoming UBX or TTY (AT+) commands and polls.
 
 See sample [ubxsimulator.json](https://github.com/semuconsulting/pyubxutils/blob/main/examples/ubxsimulator.json) configuration file in the \examples folder, and the [Sphinx API documentation](https://www.semuconsulting.com/pyubxutils/pyubxutils.html#module-pyubxutils.ubxsimulator).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyubxutils Release Notes
 
+### RELEASE 1.0.3
+
+ENHANCEMENTS:
+
+1. UBXSimulator now supports limited TTY (AT+) commands. `AT+ECHO=OK` and `AT+ECHO=Error` commands will simulate an `OK` or `Error` TTY response. An `AT+ECHO=xxxxxx` command will echo back the `xxxxxx` string.
+
 ### RELEASE 1.0.2
 
 FIXES:

--- a/docs/pyubxutils.rst
+++ b/docs/pyubxutils.rst
@@ -9,85 +9,85 @@ pyubxutils.exceptions module
 
 .. automodule:: pyubxutils.exceptions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.globals module
 -------------------------
 
 .. automodule:: pyubxutils.globals
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.helpers module
 -------------------------
 
 .. automodule:: pyubxutils.helpers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxbase module
 -------------------------
 
 .. automodule:: pyubxutils.ubxbase
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxcompare module
 ----------------------------
 
 .. automodule:: pyubxutils.ubxcompare
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxload module
 -------------------------
 
 .. automodule:: pyubxutils.ubxload
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxsave module
 -------------------------
 
 .. automodule:: pyubxutils.ubxsave
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxsetrate module
 ----------------------------
 
 .. automodule:: pyubxutils.ubxsetrate
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxsimulator module
 ------------------------------
 
 .. automodule:: pyubxutils.ubxsimulator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 pyubxutils.ubxsimulator\_cli module
 -----------------------------------
 
 .. automodule:: pyubxutils.ubxsimulator_cli
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: pyubxutils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: BSD License",
     "Topic :: Utilities",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: GIS",

--- a/src/pyubxutils/_version.py
+++ b/src/pyubxutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/src/pyubxutils/globals.py
+++ b/src/pyubxutils/globals.py
@@ -22,10 +22,11 @@ EPILOG = (
 """CLI argument parser epilog"""
 MINNMEA = "minnmea"
 MINUBX = "minubx"
-ALLNMEA_CLS = [b"\xF0", b"\xF1"]
-MINMMEA_ID = [b"\xF0\x00", b"\xF0\x02", b"\xF0\x03", b"\xF0\x04", b"\xF0\x05"]
+ALLNMEA_CLS = [b"\xf0", b"\xf1"]
+MINMMEA_ID = [b"\xf0\x00", b"\xf0\x02", b"\xf0\x03", b"\xf0\x04", b"\xf0\x05"]
 ALLUBX_CLS = [b"\x01"]
 MINUBX_ID = [b"\x01\x04", b"\x01\x07", b"\x01\x35"]
+TTY_PROTOCOL = 32
 
 VERBOSITY_CRITICAL = -1
 """Verbosity critical"""

--- a/src/pyubxutils/ubxsetrate.py
+++ b/src/pyubxutils/ubxsetrate.py
@@ -7,7 +7,7 @@ to a local serial port via the UBX CFG-MSG command.
 
 Usage:
 
-ubxsetrate --port dev/tty.usbmodem1301 --baudrate 38400 --timeout 5 
+ubxsetrate --port dev/tty.usbmodem1301 --baudrate 38400 --timeout 5
    --msgClass 0xf1 --msgID 0x00 --rate 1 --verbosity 1
 
 or (to turn off all NMEA messages):

--- a/src/pyubxutils/ubxsimulator.py
+++ b/src/pyubxutils/ubxsimulator.py
@@ -19,14 +19,14 @@ Example usage:
         for raw, parsed in ubr:
             print(parsed)
 
-Generates mock acknowledgements (ACK-ACK) for valid incoming UBX commands
-and polls.
+Generates mock acknowledgements (ACK-ACK) for valid incoming UBX or TTY (AT+)
+commands and polls.
 
 See sample ubxsimulator.json configuration file in the \\\\examples folder.
 
 NB: Principally intended for testing Python GNSS application functionality.
 There is currently no attempt to simulate real-world satellite geodetics,
-though this could be done using e.g. the Python `skyfield` library and the 
+though this could be done using e.g. the Python `skyfield` library and the
 relevant satellite TLE (orbital elements) files. I may look into adding
 such functionality as and when time permits. Contributions welcome.
 
@@ -65,7 +65,7 @@ from pyubx2 import (
     utc2itow,
 )
 
-from pyubxutils.globals import EARTH_RADIUS, UBXSIMULATOR
+from pyubxutils.globals import EARTH_RADIUS, UBXSIMULATOR, TTY_PROTOCOL
 
 DEFAULT_INTERVAL = 1000  # milliseconds
 DEFAULT_TIMEOUT = 3  # seconds
@@ -303,6 +303,17 @@ class UBXSimulator:
                 self._do_monver(outq)
             if data.identity == "CFG-RATE":
                 self._do_cfgrate(data, outq)
+        else:
+            raw = None
+            if data == b"AT+ECHO=OK\r\n":
+                raw = b"\r\nOK\r\n\r\n"
+            elif data == b"AT+ECHO=ERROR\r\n":
+                raw = b"\r\nError\r\n\r\n"
+            elif data[0:8] == b"AT+ECHO=":
+                raw = data[8:]
+            if raw is not None:
+                outq.put(raw)
+                self.logger.info(f"TTY Response Sent by Simulator: {raw}\n")
 
     def _do_send(self, msg: UBXMessage, outq: Queue):
         """
@@ -434,10 +445,14 @@ class UBXSimulator:
         """
         Simulated write to receiver.
 
-        :param bytes data: UBX data
+        :param bytes data: UBX or TTY data
         """
 
-        prot = protocol(data)
+        if data[0:3] == b"AT+":
+            prot = TTY_PROTOCOL
+        else:
+            prot = protocol(data)
+
         try:
             if prot == RTCM3_PROTOCOL:
                 rtm = RTCMReader.parse(data)
@@ -448,6 +463,9 @@ class UBXSimulator:
                 ubx = UBXReader.parse(data, msgmode=msgmode)
                 self._inqueue.put(ubx)
                 val = ("UBX", ubx)
+            elif prot == TTY_PROTOCOL:
+                self._inqueue.put(data)
+                val = (f"TTY AT+ {prot}", None)
             else:
                 val = (f"Other Protocol {prot}", None)
         except (

--- a/src/pyubxutils/ubxsimulator.py
+++ b/src/pyubxutils/ubxsimulator.py
@@ -65,7 +65,7 @@ from pyubx2 import (
     utc2itow,
 )
 
-from pyubxutils.globals import EARTH_RADIUS, UBXSIMULATOR, TTY_PROTOCOL
+from pyubxutils.globals import EARTH_RADIUS, TTY_PROTOCOL, UBXSIMULATOR
 
 DEFAULT_INTERVAL = 1000  # milliseconds
 DEFAULT_TIMEOUT = 3  # seconds


### PR DESCRIPTION
# pyubxutils Pull Request Template

## Description

ENHANCEMENTS:

1. UBXSimulator now supports limited TTY (AT+) commands. `AT+ECHO=OK` and `AT+ECHO=Error` commands will simulate an `OK` or `Error` TTY response. An `AT+ECHO=xxxxxx` command will echo back the `xxxxxx` string.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
