### PR TITLE
RC 1.0.6 - allow mixed formats in ubxcompare

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,55 +1,79 @@
 {
-    // These test, build and deploy tasks are targeted at a venv
+    // pyubxutils VSCode workflow.
+    //
+    // These build, install and test tasks are targeted at a venv
     // called 'pygpsclient' located in the user's home directory.
     // Set your workspace default VSCode Python interpreter to
     // this venv, i.e.
-    // "${userHome}/pygpsclient/bin/python3" on linux/macos
-    // "${userHome}/pygpsclient/Scripts/python" on windows
+    // "${userHome}/pygpsclient/bin/python3" on Linux/MacOS
+    // "C:/Users/user/pygpsclient/Scripts/python.exe" on Windows
+    //
+    // The "Test" task will initialise the venv and execute all
+    // necessary build and installation precursors.
+    //
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Delete Venv",
+            "type": "shell",
+            "command": "rm",
+            "args": [
+                "-rf",
+                "${config:venv}",
+            ],
+            "problemMatcher": []
+        },
+        {
             "label": "Create Venv",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
+            "type": "shell",
+            "command": "${config:python.systemPath}",
             "args": [
                 "-m",
                 "venv",
                 "${config:venv}",
-                //"--system-site-packages"
             ],
-            "problemMatcher": []
+            "problemMatcher": [],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "Delete Venv",
+            ],
         },
         {
-            "label": "Run Local Version",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
+            "label": "Activate Venv",
+            "type": "shell",
+            "command": "source",
             "args": [
-                "-m",
-                "pygpsclient",
-                "--ntripcasteruser",
-                "semuadmin",
-                "--ntripcasterpassword",
-                "testpassword",
-                "--verbosity",
-                "3"
+                "~/pygpsclient/bin/activate",
             ],
-            "options": {
-                "cwd": "src"
-            },
-            "problemMatcher": []
+            "problemMatcher": [],
         },
         {
             "label": "Install Deploy Dependencies",
-            "type": "process",
+            "type": "shell",
             "command": "${config:python.defaultInterpreterPath}",
             "args": [
                 "-m",
                 "pip",
                 "install",
+                "--upgrade",
                 "--group",
                 "deploy"
             ],
-            "problemMatcher": []
+            "problemMatcher": [],
+        },
+        {
+            "label": "Install Optional Dependencies",
+            "type": "shell",
+            "command": "${config:python.defaultInterpreterPath}",
+            "args": [
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--group",
+                "optional"
+            ],
+            "problemMatcher": [],
         },
         {
             "label": "Clean",
@@ -64,13 +88,14 @@
                 "${config:modulename}.egg-info",
             ],
             "windows": {
-                "command": "rm",
+                "command": "Remove-Item",
                 "args": [
-                    "-R",
-                    "-Path",
-                    "'src/${config:modulename}.egg-info','build','dist','htmlcov','docs/_build'",
+                    "-Recurse",
+                    "-Force",
                     "-ErrorAction",
-                    "SilentlyContinue" // doesn't work! - stops on exit code 1 anyway
+                    "SilentlyContinue", // doesn't work! - stops on exit code 1 anyway
+                    "-Path",
+                    "'build','dist','htmlcov','docs/_build','src/${config:modulename}.egg-info'",
                 ]
             },
             "options": {
@@ -80,7 +105,7 @@
         },
         {
             "label": "Sort Imports",
-            "type": "process",
+            "type": "shell",
             "command": "${config:python.defaultInterpreterPath}",
             "args": [
                 "-m",
@@ -93,7 +118,7 @@
         },
         {
             "label": "Format",
-            "type": "process",
+            "type": "shell",
             "command": "${config:python.defaultInterpreterPath}",
             "args": [
                 "-m",
@@ -116,34 +141,18 @@
         {
             "label": "Security",
             "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
+            "command": "bandit",
             "args": [
-                "-m",
-                "bandit",
                 "-c",
                 "pyproject.toml",
                 "-r",
-                "."
+                "src/pygpsclient"
             ],
             "problemMatcher": []
         },
         {
-            "label": "Test",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
-            "args": [
-                "-m",
-                "pytest"
-            ],
-            "problemMatcher": [],
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            }
-        },
-        {
             "label": "Build",
-            "type": "process",
+            "type": "shell",
             "command": "${config:python.defaultInterpreterPath}",
             "args": [
                 "-m",
@@ -155,12 +164,12 @@
             "problemMatcher": [],
             "dependsOrder": "sequence",
             "dependsOn": [
+                //"Create Venv",
+                "Install Deploy Dependencies",
+                "Install Optional Dependencies",
                 "Clean",
-                "Security",
                 "Sort Imports",
                 "Format",
-                "Pylint",
-                "Test",
             ],
             "group": {
                 "kind": "build",
@@ -168,8 +177,55 @@
             }
         },
         {
+            "label": "Install", // into Virtual Environment
+            "type": "shell",
+            "command": "${config:python.defaultInterpreterPath}",
+            "args": [
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                // wildcard only works on Posix platforms
+                "${workspaceFolder}/dist/pyubxutils-*-py3-none-any.whl",
+            ],
+            "windows": {
+                "command": "${config:python.defaultInterpreterPath}",
+                "args": [
+                    "-m",
+                    "pip",
+                    "install",
+                    "--force-reinstall",
+                    "${workspaceFolder}/dist/pyubxutils-1.0.6-py3-none-any.whl",
+                ]
+            },
+            "problemMatcher": [],
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "${config:python.defaultInterpreterPath}",
+            "args": [
+                "-m",
+                "pytest"
+            ],
+            "problemMatcher": [],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "Activate Venv",
+                "Build",
+                "Install", // have to install before running pylint
+                "Pylint",
+                "Security",
+                "Sphinx HTML",
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        {
             "label": "Sphinx",
-            "type": "process",
+            "type": "shell",
             "command": "sphinx-apidoc",
             "args": [
                 "--ext-autodoc",
@@ -184,7 +240,7 @@
         },
         {
             "label": "Sphinx HTML",
-            "type": "process",
+            "type": "shell",
             "command": "/usr/bin/make",
             "windows": {
                 "command": "${workspaceFolder}/docs/make.bat"
@@ -202,8 +258,8 @@
             "problemMatcher": []
         },
         {
-            "label": "Sphinx Deploy to S3", // needs AWS credentials
-            "type": "process",
+            "label": "Sphinx Deploy", // needs AWS S3 credentials
+            "type": "shell",
             "command": "aws",
             "args": [
                 "s3",
@@ -219,29 +275,19 @@
             "problemMatcher": []
         },
         {
-            "label": "Install Locally",
-            "type": "process",
-            "command": "${config:python.defaultInterpreterPath}",
+            "label": "Run from Source",
+            "type": "shell",
+            "command": "python3",
             "args": [
                 "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                "--force-reinstall",
-                "--find-links=${workspaceFolder}/dist",
-                "${workspaceFolderBasename}",
-                // "--target",
-                // "${config:venv}/Lib/site-packages"
+                "pygpsclient",
+                //"--verbosity",
+                //"3"
             ],
             "options": {
-                "cwd": "dist"
+                "cwd": "${workspaceFolder}/src"
             },
-            "dependsOrder": "sequence",
-            "dependsOn": [
-                "Build",
-                "Sphinx HTML"
-            ],
             "problemMatcher": []
-        }
+        },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ ubxsetrate -h
 class pyubxutils.ubxcompare.UBXCompare(infiles, form, diffsonly)
 ```
 
-A simple CLI utility for comparing the contents of two or more u-blox configuration files. Files can be in text (\*.txt) format (as used by u-center or ArduSimple) or binary (\*.ubx) format (as used by [PyGPSClient](https://github.com/semuconsulting/PyGPSClient) or [ubxsave](#ubxsave)).
+A simple CLI utility for comparing the contents of two or more u-blox configuration files. Files can be in text (\*.txt) format (as used by u-center or ArduSimple) or binary (\*.ubx) format (as used by [PyGPSClient](https://github.com/semuconsulting/PyGPSClient) or [ubxsave](#ubxsave)). If the format argument `--format` or `-F` is set to 2 (`FORMAT_ALL`), the file format will be derived from the file suffix i.e. `*.txt` for text or `*.ubx` for binary.
 
 e.g. 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pyubxutils Release Notes
 
+### RELEASE 1.0.6
+
+ENHANCMENTS:
+
+1. Allow mixed file formats (ubx & txt) in ubxcompare - addresses feature request https://github.com/semuconsulting/pyubxutils/issues/10
+
 ### RELEASE 1.0.5
 
 FIXES:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,15 @@
 #
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath("../src"))
-
 from pyubxutils import version as VERSION
+
+# get path to site-packages (source) folder within venv
+pypath = (
+    f"{os.path.expanduser("~")}/pygpsclient/lib/python"
+    f"{sys.version_info.major}.{sys.version_info.minor}/site-packages"
+)
+print(f"\n\033[1mUsing absolute path:\033[0m \033[95m{pypath}\033[0m\n")
+sys.path.insert(0, os.path.abspath(pypath))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-from pyubxutils import version as VERSION
+
 
 # get path to site-packages (source) folder within venv
 pypath = (
@@ -21,6 +21,8 @@ pypath = (
 )
 print(f"\n\033[1mUsing absolute path:\033[0m \033[95m{pypath}\033[0m\n")
 sys.path.insert(0, os.path.abspath(pypath))
+
+from pyubxutils import version as VERSION
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,13 +4,13 @@
    contain the root `toctree` directive.
 
 Welcome to pyubxutils's documentation!
-==================================
+======================================
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-
+   modules.rst
 
 Indices and tables
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ repository = "https://github.com/semuconsulting/pyubx2"
 changelog = "https://github.com/semuconsulting/pyubx2/blob/master/RELEASE_NOTES.md"
 
 [dependency-groups]
+optional = []
 build = [
     "awscli",
     "build",

--- a/src/pyubxutils/_version.py
+++ b/src/pyubxutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/src/pyubxutils/ubxbase.py
+++ b/src/pyubxutils/ubxbase.py
@@ -237,7 +237,7 @@ class UBXBase:
         # or waittime has been exceeded.
         while not stop.is_set():
             try:
-                (_, parsed_data) = ubr.read()
+                _, parsed_data = ubr.read()
                 if parsed_data is not None:
                     if (
                         parsed_data.identity in (ACK, NAK)

--- a/src/pyubxutils/ubxload.py
+++ b/src/pyubxutils/ubxload.py
@@ -94,7 +94,7 @@ class UBXLoader:
             ubl = UBXReader(stream, msgmode=SETPOLL)
             eof = False
             while not eof:
-                (raw_data, parsed_data) = ubl.read()
+                raw_data, parsed_data = ubl.read()
                 if raw_data is None:
                     eof = True
                 else:
@@ -118,7 +118,7 @@ class UBXLoader:
         # or waittime has been exceeded.
         while not stop.is_set():
             try:
-                (_, parsed_data) = ubr.read()
+                _, parsed_data = ubr.read()
                 if parsed_data is not None:
                     if (
                         parsed_data.identity in (ACK, NAK)

--- a/src/pyubxutils/ubxsave.py
+++ b/src/pyubxutils/ubxsave.py
@@ -145,7 +145,7 @@ class UBXSaver:
             try:
                 if stream.in_waiting:
                     lock.acquire()
-                    (raw_data, parsed_data) = ubr.read()
+                    raw_data, parsed_data = ubr.read()
                     lock.release()
                     if parsed_data is not None:
                         if parsed_data.identity == "CFG-VALGET":
@@ -169,7 +169,7 @@ class UBXSaver:
         while True:
             cfgdata = []
             while queue.qsize() > 0:
-                (_, parsed) = queue.get()
+                _, parsed = queue.get()
                 if parsed.identity == "CFG-VALGET":
                     for keyname in dir(parsed):
                         if keyname[0:3] == "CFG":

--- a/src/pyubxutils/ubxsimulator.py
+++ b/src/pyubxutils/ubxsimulator.py
@@ -264,7 +264,7 @@ class UBXSimulator:
                 msgid = msg["msgId"]
                 rate = msg.get("rate", 1)
                 if not loops % rate:
-                    attrs = {**time_attrs, **global_attrs, **msg["attrs"]}
+                    attrs = {**time_attrs, **global_attrs, **msg.get("attrs", {})}
                     ubx = UBXMessage(msgcls, msgid, GET, **attrs)
                     outq.put(ubx.serialize())
 
@@ -275,7 +275,7 @@ class UBXSimulator:
                 rate = msg.get("rate", 1)
                 if not loops % rate:
                     # pynmeagps automatically defaults time to now()
-                    attrs = {**global_attrs, **msg["attrs"]}
+                    attrs = {**global_attrs, **msg.get("attrs", {})}
                     nme = NMEAMessage(talker, msgid, GET, **attrs)
                     outq.put(nme.serialize())
 


### PR DESCRIPTION
# pyubxutils Pull Request Template

## Description

1. Allow mixed file formats (ubx & txt) in ubxcompare - addresses feature request https://github.com/semuconsulting/pyubxutils/issues/10

Fixes #10 

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] tested with mixed *.txt and *.ubx files

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyubx2/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyubx2/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
